### PR TITLE
Less logging from http

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -3,7 +3,8 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information",
-      "NpmDockerSync": "Debug"
+      "System.Net.Http.HttpClient": "Warning",
+      "NpmDockerSync": "Information"
     }
   },
   "DOCKER_HOST": "unix:///var/run/docker.sock",


### PR DESCRIPTION
This pull request updates the logging configuration in `appsettings.json` to adjust log verbosity for certain components.

Logging configuration updates:

* Changed the log level for `NpmDockerSync` from `Debug` to `Information` to reduce log noise.
* Added a log level setting for `System.Net.Http.HttpClient` and set it to `Warning` to suppress less important HTTP client logs.