### PR TITLE
Improve logging

### DIFF
--- a/Services/SimpleConsoleFormatter.cs
+++ b/Services/SimpleConsoleFormatter.cs
@@ -62,10 +62,11 @@ public class SimpleConsoleFormatter : ConsoleFormatter
 
         textWriter.Write(" ");
 
-        // Message
-        textWriter.WriteLine(message);
+        // Message (replace newlines with space to keep single line)
+        var singleLineMessage = message.Replace("\r\n", " ").Replace("\n", " ").Replace("\r", " ");
+        textWriter.WriteLine(singleLineMessage);
 
-        // Exception
+        // Exception (keep on separate lines for readability)
         if (logEntry.Exception != null)
         {
             textWriter.WriteLine(logEntry.Exception.ToString());

--- a/appsettings.json
+++ b/appsettings.json
@@ -3,7 +3,8 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information",
-      "System.Net.Http.HttpClient": "Warning",
+      "System.Net.Http": "None",
+      "System.Net.Http.HttpClient": "None",
       "NpmDockerSync": "Information"
     }
   },


### PR DESCRIPTION
This pull request refactors the handling of container names throughout the Docker monitoring and synchronization services to improve logging clarity and maintain consistency. Instead of relying solely on container IDs, the code now consistently uses human-readable container names in log messages and method signatures. Additionally, log formatting is improved to ensure single-line output for messages, making logs easier to read and parse.

**Container name propagation and logging improvements:**

* All relevant methods in `SyncOrchestrator` and `DockerMonitorService` now accept and use a `containerName` parameter in addition to `containerId`, ensuring that log messages consistently reference the container by name where possible. [[1]](diffhunk://#diff-d8f8d009afc5ebb3f8b142ecd019c9a29e43a5abd05c0d6c5f9246dbe037c4d7L66-R68) [[2]](diffhunk://#diff-d8f8d009afc5ebb3f8b142ecd019c9a29e43a5abd05c0d6c5f9246dbe037c4d7L132-R134) [[3]](diffhunk://#diff-d8f8d009afc5ebb3f8b142ecd019c9a29e43a5abd05c0d6c5f9246dbe037c4d7L143-R151) [[4]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L54-R54) [[5]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L75-R82) [[6]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L96-R96) [[7]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L112-R122) [[8]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L138-R148) [[9]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L166-R167) [[10]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L198-R209) [[11]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L227-R228) [[12]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L257-R258) [[13]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L267-R273) [[14]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L284-R295) [[15]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L311-R327) [[16]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L338-R384)

* All log messages throughout the orchestration and removal process have been updated to use `containerName` instead of or in addition to `containerId`, resulting in more informative and human-friendly logs. [[1]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L75-R82) [[2]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L166-R167) [[3]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L198-R209) [[4]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L227-R228) [[5]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L257-R258) [[6]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L267-R273) [[7]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L284-R295) [[8]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L311-R327) [[9]](diffhunk://#diff-3a106e3d1718c46aaafd0558f568c205985b5f034129b5192e658217eb5be953L338-R384)

**Log formatting enhancements:**

* The `SimpleConsoleFormatter` now replaces newlines in log messages with spaces, ensuring that each log entry remains on a single line for better readability and log parsing. Exceptions are still printed on separate lines for clarity.

**Stream creation logging improvements:**

* When creating streams, the log now includes a concise summary with protocol information (TCP/UDP) in a structured format, making it easier to quickly understand the stream configuration from the logs.

These changes collectively improve the maintainability of the codebase and the clarity of its operational logs, making it easier to debug and monitor container-related events.