### PR TITLE
Restore label hashes during NPM state restoration

### DIFF
--- a/Services/DockerMonitorService.cs
+++ b/Services/DockerMonitorService.cs
@@ -38,8 +38,8 @@ public class DockerMonitorService : BackgroundService
             // Initialize network detection
             await _networkService.InitializeAsync(stoppingToken);
 
-            // Restore state from NPM (maps container IDs to proxy/stream IDs)
-            await _syncOrchestrator.RestoreStateFromNpm(stoppingToken);
+            // Restore state from NPM (maps container IDs to proxy/stream IDs and label hashes)
+            await _syncOrchestrator.RestoreStateFromNpm(_dockerClient, stoppingToken);
 
             // Perform initial scan of all containers
             await PerformInitialScan(stoppingToken);


### PR DESCRIPTION
SyncOrchestrator's RestoreStateFromNpm now restores label hashes for managed containers by inspecting them via DockerClient. This enables accurate label change detection and improves logging for container processing events.